### PR TITLE
SPORTS-231 Add middleware for validating tokens

### DIFF
--- a/api/src/authenticator.ts
+++ b/api/src/authenticator.ts
@@ -1,0 +1,21 @@
+import { Request } from 'express';
+
+import { en } from './lang/en';
+import TokenError from './error/TokenError';
+
+/**
+ * Get token from header in request.
+ *
+ * @param {Request} req
+ */
+export function getTokenFromHeaders(req: Request) {
+  const {
+    headers: { authorization }
+  } = req;
+
+  if (authorization && authorization.split(' ')[0] === 'Bearer' && authorization.split(' ')[1] !== undefined) {
+    return { token: authorization.split(' ')[1] };
+  }
+
+  return { error: new TokenError(en.EMPTY_TOKEN) };
+}

--- a/api/src/error/TokenError.ts
+++ b/api/src/error/TokenError.ts
@@ -1,0 +1,15 @@
+import CustomError from './CustomError';
+
+/**
+ * Token error class to handle token errors.
+ */
+class TokenError extends CustomError {
+  constructor(message: string, details?: string, code?: number) {
+    super(message);
+    this.details = details;
+    this.code = code;
+    Object.setPrototypeOf(this, TokenError.prototype);
+  }
+}
+
+export default TokenError;

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -25,8 +25,10 @@ const server = new ApolloServer({
         token = headerResponse.token;
 
         data = await validateToken(token);
-      } else {
-        data = { error: new Error('Token not present') };
+      }
+
+      if (headerResponse.error) {
+        data = headerResponse;
       }
     } catch (e) {
       // Just logging for now. Lets add a dedicated logger here later

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -25,6 +25,8 @@ const server = new ApolloServer({
         token = headerResponse.token;
 
         data = await validateToken(token);
+      } else {
+        data = { error: new Error('Token not present') };
       }
     } catch (e) {
       // Just logging for now. Lets add a dedicated logger here later

--- a/api/src/lang/en.ts
+++ b/api/src/lang/en.ts
@@ -2,6 +2,7 @@ export const en = {
   SUCCESS: 'Success',
   INVALID_TOKEN: 'Invalid token',
   TOKEN_EXPIRED: 'Token has expired',
+  EMPTY_TOKEN: 'Token cannot be empty',
   LOGIN_SUCCESSFUL: 'Login successful',
   INVALID_PASSWORD: 'Invalid Password',
   EMPLOYEE_NOT_FOUND: 'Employee not Found',

--- a/api/src/middlewares/validateToken.ts
+++ b/api/src/middlewares/validateToken.ts
@@ -9,9 +9,9 @@ import { withOnlyAttrs } from '../utils/object';
  */
 export async function validateToken(token: string): Promise<any> {
   try {
-    const data = await verify(token);
+    const user = await verify(token);
 
-    return withOnlyAttrs(data, ['id', 'employeeId']);
+    return { user: withOnlyAttrs(user, ['id', 'employeeId']) };
   } catch (error) {
     return { error };
   }

--- a/api/src/middlewares/validateToken.ts
+++ b/api/src/middlewares/validateToken.ts
@@ -1,8 +1,17 @@
 import { verify } from '../utils/jwt';
+import { withOnlyAttrs } from '../utils/object';
 
+/**
+ * Middleware for validating tokens
+ *
+ * @param {token} string
+ * @returns {Promise<any>}
+ */
 export async function validateToken(token: string): Promise<any> {
   try {
-    await verify(token);
+    const data = await verify(token);
+
+    return withOnlyAttrs(data, ['id', 'employeeId']);
   } catch (error) {
     return { error };
   }

--- a/api/src/middlewares/validateToken.ts
+++ b/api/src/middlewares/validateToken.ts
@@ -1,0 +1,9 @@
+import { verify } from '../utils/jwt';
+
+export async function validateToken(token: string): Promise<any> {
+  try {
+    await verify(token);
+  } catch (error) {
+    return { error };
+  }
+}

--- a/api/src/models/Context.ts
+++ b/api/src/models/Context.ts
@@ -2,6 +2,8 @@ import Knex from 'knex';
 
 interface Context {
   db: Knex;
+  error: any;
+  authToken: string;
 }
 
 export default Context;

--- a/api/src/mutations/refreshAccessToken.ts
+++ b/api/src/mutations/refreshAccessToken.ts
@@ -1,7 +1,6 @@
 import HttpStatus from 'http-status-codes';
 
 import Context from '../models/Context';
-import { buildError } from '../utils/errors';
 import * as tokenService from '../services/token';
 
 /**
@@ -13,11 +12,7 @@ import * as tokenService from '../services/token';
  * @returns {Object}
  */
 export const refreshAccessToken = async (parent: any, { refreshToken }: { refreshToken: string }, context: Context) => {
-  try {
-    const { accessToken, message } = await tokenService.getNewAccessToken(refreshToken);
+  const { accessToken, message } = await tokenService.getNewAccessToken(refreshToken);
 
-    return { accessToken, message, code: HttpStatus.OK };
-  } catch (err) {
-    return buildError(err);
-  }
+  return { accessToken, message, code: HttpStatus.OK };
 };

--- a/api/src/mutations/signUp.ts
+++ b/api/src/mutations/signUp.ts
@@ -2,7 +2,6 @@ import HttpStatus from 'http-status-codes';
 
 import { en } from '../lang/en';
 import Context from '../models/Context';
-import { buildError } from '../utils/errors';
 import * as userService from '../services/user';
 import MissingUserNameOrPasswordError from '../error/MissingUserNameOrPasswordError';
 
@@ -20,15 +19,11 @@ export const signUp = async (
   { password, email }: { password: string; email: string },
   context: Context
 ) => {
-  try {
-    if (!email || !password) {
-      throw new MissingUserNameOrPasswordError(en.MISSING_USERNAME_OR_PASSWORD);
-    }
-
-    await userService.createUser(password, email);
-
-    return { message: en.SUCCESS, code: HttpStatus.CREATED };
-  } catch (err) {
-    return buildError(err);
+  if (!email || !password) {
+    throw new MissingUserNameOrPasswordError(en.MISSING_USERNAME_OR_PASSWORD);
   }
+
+  await userService.createUser(password, email);
+
+  return { message: en.SUCCESS, code: HttpStatus.CREATED };
 };

--- a/api/src/utils/jwt.ts
+++ b/api/src/utils/jwt.ts
@@ -52,9 +52,7 @@ export function createRefreshToken(data: RefreshTokenData) {
  */
 export function verify(token: string) {
   try {
-    const data = jwt.verify(token, appConfig.jwt.secret || '', appConfig.jwt.verifyOptions);
-
-    return data;
+    jwt.verify(token, appConfig.jwt.secret || '', appConfig.jwt.verifyOptions);
   } catch (err) {
     if (err.name === TOKEN_EXPIRED_ERROR) {
       throw new JWTExpiredError(en.TOKEN_EXPIRED, err, HttpStatus.UNAUTHORIZED);

--- a/api/src/utils/jwt.ts
+++ b/api/src/utils/jwt.ts
@@ -52,7 +52,9 @@ export function createRefreshToken(data: RefreshTokenData) {
  */
 export function verify(token: string) {
   try {
-    jwt.verify(token, appConfig.jwt.secret || '', appConfig.jwt.verifyOptions);
+    const data = jwt.verify(token, appConfig.jwt.secret || '', appConfig.jwt.verifyOptions);
+    //  tslint:disable:no-console
+    console.log({ data });
   } catch (err) {
     if (err.name === TOKEN_EXPIRED_ERROR) {
       throw new JWTExpiredError(en.TOKEN_EXPIRED, err, HttpStatus.UNAUTHORIZED);

--- a/api/src/utils/jwt.ts
+++ b/api/src/utils/jwt.ts
@@ -53,8 +53,8 @@ export function createRefreshToken(data: RefreshTokenData) {
 export function verify(token: string) {
   try {
     const data = jwt.verify(token, appConfig.jwt.secret || '', appConfig.jwt.verifyOptions);
-    //  tslint:disable:no-console
-    console.log({ data });
+
+    return data;
   } catch (err) {
     if (err.name === TOKEN_EXPIRED_ERROR) {
       throw new JWTExpiredError(en.TOKEN_EXPIRED, err, HttpStatus.UNAUTHORIZED);


### PR DESCRIPTION
  * A new middleware to validate tokens is added.
  * It verifies the token passed as an authorization header.
  * New implementation we need to do the following check-in all resolvers where token needs to be verified
 ```
   if(context.error){
      throw context.error
   }
```
  * Every endpoint is checked but we just validate the endpoints where authentication matters
  * Error is checked and passed onto to the context object
  * Token needs to be sent in authorization header in the form `authorization: Bearer {token}`